### PR TITLE
Add Sourcing & Procurement service page and navigation links

### DIFF
--- a/bahan-hq.html
+++ b/bahan-hq.html
@@ -200,6 +200,7 @@
             <a href="index.html" class="text-2xl font-bold text-white">Procu<span class="text-white">Track</span></a> 
             
             <div class="hidden lg:flex items-center space-x-6 mx-auto"> <a href="index.html" class="nav-main-link">Home</a>
+                <a href="servis-sourcing-procurement.html" class="nav-main-link">Sourcing & Procurement</a>
                 
                 <div class="dropdown">
                     <a href="#" class="nav-main-link">About Us <span class="ml-1 text-xs">&#9662;</span></a>
@@ -242,6 +243,7 @@
         </nav>
         <div id="mobile-menu" class="hidden lg:hidden bg-[#215240] py-4">
             <a href="index.html" class="block text-center py-2 px-4 text-base text-white hover:bg-opacity-10 hover:bg-white">Home</a>
+            <a href="servis-sourcing-procurement.html" class="block text-center py-2 px-4 text-base text-white hover:bg-opacity-10 hover:bg-white">Sourcing & Procurement</a>
             <div class="mobile-dropdown-toggle block text-center py-2 px-4 text-base text-white hover:bg-opacity-10 hover:bg-white cursor-pointer">About Us <span class="ml-1 text-xs">&#9662;</span></div>
             <div class="mobile-dropdown-content hidden">
                 <a href="tentang-kami.html" class="block text-center py-2 px-4 text-base text-white hover:bg-opacity-10 hover:bg-white">Tentang Kami</a>

--- a/index.html
+++ b/index.html
@@ -312,6 +312,7 @@
             
             <div class="hidden lg:flex items-center space-x-6 mx-auto">  
                 <a href="index.html" class="nav-main-link">Home</a>
+                <a href="servis-sourcing-procurement.html" class="nav-main-link">Sourcing & Procurement</a>
                 
                 <div class="dropdown">
                     <a href="#" class="nav-main-link">About Us <span class="ml-1 text-xs">&#9662;</span></a>
@@ -354,6 +355,7 @@
         </nav>
         <div id="mobile-menu" class="hidden lg:hidden bg-[#215240] py-4">
             <a href="index.html" class="block text-center py-2 px-4 text-base text-white hover:bg-opacity-10 hover:bg-white">Home</a>
+            <a href="servis-sourcing-procurement.html" class="block text-center py-2 px-4 text-base text-white hover:bg-opacity-10 hover:bg-white">Sourcing & Procurement</a>
             <div class="mobile-dropdown-toggle block text-center py-2 px-4 text-base text-white hover:bg-opacity-10 hover:bg-white cursor-pointer">About Us <span class="ml-1 text-xs">&#9662;</span></div>
             <div class="mobile-dropdown-content hidden">
                 <a href="tentang-kami.html" class="block text-center py-2 px-4 text-base text-white hover:bg-opacity-10 hover:bg-white">Tentang Kami</a>

--- a/key-in.html
+++ b/key-in.html
@@ -338,6 +338,7 @@
             <a href="index.html" class="text-2xl font-bold text-white">Procu<span class="text-white">Track</span></a>
             <div class="hidden lg:flex items-center space-x-8">
                 <a href="index.html#pengenalan-syarikat" class="hover:text-[#EBF2EE]">Tentang Kami</a>
+                <a href="servis-sourcing-procurement.html" class="hover:text-[#EBF2EE]">Sourcing & Procurement</a>
                 <a href="index.html#kelebihan" class="hover:text-[#EBF2EE]">Kelebihan</a>
                 <a href="index.html#cara-kerja" class="hover:text-[#EBF2EE]">Cara Kerja</a>
                 <a href="index.html#pendapatan" class="hover:text-[#EBF2EE]">Potensi Pendapatan</a>
@@ -355,6 +356,7 @@
         </nav>
         <div id="mobile-menu" class="hidden lg:hidden bg-[#215240] py-4">
             <a href="index.html#pengenalan-syarikat" class="block text-center py-2 px-4 text-sm hover:bg-opacity-10">Tentang Kami</a>
+            <a href="servis-sourcing-procurement.html" class="block text-center py-2 px-4 text-sm hover:bg-opacity-10">Sourcing & Procurement</a>
             <a href="index.html#kelebihan" class="block text-center py-2 px-4 text-sm hover:bg-opacity-10">Kelebihan</a>
             <a href="index.html#cara-kerja" class="block text-center py-2 px-4 text-sm hover:bg-opacity-10">Cara Kerja</a>
             <a href="index.html#pendapatan" class="block text-center py-2 px-4 text-sm hover:bg-opacity-10">Potensi Pendapatan</a>

--- a/potensi-pendapatan.html
+++ b/potensi-pendapatan.html
@@ -196,6 +196,7 @@
             <a href="index.html" class="text-2xl font-bold text-white">Procu<span class="text-white">Track</span></a>
             
             <div class="hidden lg:flex items-center space-x-6 mx-auto"> <a href="index.html" class="nav-main-link">Home</a>
+                <a href="servis-sourcing-procurement.html" class="nav-main-link">Sourcing & Procurement</a>
                 
                 <div class="dropdown">
                     <a href="#" class="nav-main-link">About Us <span class="ml-1 text-xs">&#9662;</span></a>
@@ -238,6 +239,7 @@
         </nav>
         <div id="mobile-menu" class="hidden lg:hidden bg-[#215240] py-4">
             <a href="index.html" class="block text-center py-2 px-4 text-base text-white hover:bg-opacity-10 hover:bg-white">Home</a>
+            <a href="servis-sourcing-procurement.html" class="block text-center py-2 px-4 text-base text-white hover:bg-opacity-10 hover:bg-white">Sourcing & Procurement</a>
             <div class="mobile-dropdown-toggle block text-center py-2 px-4 text-base text-white hover:bg-opacity-10 hover:bg-white cursor-pointer">About Us <span class="ml-1 text-xs">&#9662;</span></div>
             <div class="mobile-dropdown-content hidden">
                 <a href="tentang-kami.html" class="block text-center py-2 px-4 text-base text-white hover:bg-opacity-10 hover:bg-white">Tentang Kami</a>

--- a/servis-sourcing-procurement.html
+++ b/servis-sourcing-procurement.html
@@ -1,0 +1,232 @@
+<!DOCTYPE html>
+<html lang="ms" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Servis Sourcing & Procurement - ProcuTrack</title>
+    <meta name="description" content="Terokai servis sourcing dan procurement ProcuTrack untuk bantu bisnes anda mendapatkan produk berkualiti dari China ke Malaysia.">
+    <meta name="keywords" content="sourcing, procurement, import china, ProcuTrack, servis perolehan">
+    <link rel="icon" href="assets/images/favicon.ico" type="image/x-icon">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
+    <style>
+        body { font-family: 'Poppins', sans-serif; background-color: #F5F5F0; animation: fadeIn 0.5s ease-in-out; }
+        .cta-button { transition: all 0.3s ease; background-color: #215240; color: white; border-radius: 0.5rem; box-shadow: 0 4px 15px rgba(33,82,64,0.3); }
+        .cta-button:hover { transform: translateY(-3px); box-shadow: 0 8px 20px rgba(33,82,64,0.4); background-color: #1A4234; }
+        .dropdown { position: relative; display: inline-block; }
+        .dropdown-content { display: none; position: absolute; background-color: #215240; min-width:160px; box-shadow:0px 8px 16px rgba(0,0,0,0.2); z-index:10; border-radius:0.5rem; overflow:hidden; top:calc(100% + 10px); left:50%; transform:translateX(-50%); opacity:0; visibility:hidden; transition: opacity .3s ease, visibility .3s ease, transform .3s ease; }
+        .dropdown:hover .dropdown-content { display:block; opacity:1; visibility:visible; transform:translateX(-50%); }
+        .dropdown-content a { color:white !important; padding:12px 16px; text-decoration:none; display:block; text-align:center; font-weight:500; transition:background-color .2s ease; white-space:nowrap; }
+        .dropdown-content a:hover { background-color:#1A4234; }
+        h1, h2, h3, h4 { color:#215240 !important; }
+        #header nav a { color:rgba(255,255,255,0.7); font-weight:500; transition:color .2s ease; }
+        #header nav a:hover { color:white; }
+        #header nav a .text-white { color:white !important; }
+        #mobile-menu-button { color:white !important; }
+        .nav-active-link { color:#ffffff !important; font-weight:700 !important; border-bottom:2px solid #FACC15; padding-bottom:4px; }
+        footer p, footer a { color:rgba(255,255,255,0.7) !important; transition:color .2s ease; }
+        footer a:hover { color:white !important; }
+        @keyframes fadeIn { from {opacity:0;} to {opacity:1;} }
+    </style>
+</head>
+<body>
+    <header id="header" class="bg-[#215240]">
+        <nav class="container mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="index.html" class="text-2xl font-bold text-white">Procu<span class="text-white">Track</span></a>
+            <div class="hidden lg:flex items-center space-x-6 mx-auto">
+                <a href="index.html" class="nav-main-link">Home</a>
+                <a href="servis-sourcing-procurement.html" class="nav-main-link">Sourcing & Procurement</a>
+                <div class="dropdown">
+                    <a href="#" class="nav-main-link">About Us <span class="ml-1 text-xs">&#9662;</span></a>
+                    <div class="dropdown-content">
+                        <a href="tentang-kami.html">Tentang Kami</a>
+                        <a href="soalan-lazim.html">Soalan Lazim</a>
+                    </div>
+                </div>
+                <div class="dropdown">
+                    <a href="#" class="nav-main-link">Activity <span class="ml-1 text-xs">&#9662;</span></a>
+                    <div class="dropdown-content">
+                        <a href="key-in.html">Key-In Tempahan</a>
+                        <a href="register.html">Daftar Sekarang</a>
+                    </div>
+                </div>
+                <div class="dropdown">
+                    <a href="#" class="nav-main-link">Careers <span class="ml-1 text-xs">&#9662;</span></a>
+                    <div class="dropdown-content">
+                        <a href="kelebihan.html">Kelebihan</a>
+                    </div>
+                </div>
+                <div class="dropdown">
+                    <a href="#" class="nav-main-link">Shop <span class="ml-1 text-xs">&#9662;</span></a>
+                    <div class="dropdown-content">
+                        <a href="bahan-hq.html">Bahan HQ</a>
+                        <a href="potensi-pendapatan.html">Potensi Pendapatan</a>
+                        <a href="sokongan.html">Sokongan</a>
+                    </div>
+                </div>
+            </div>
+            <button id="mobile-menu-button" class="lg:hidden text-white ml-auto">
+                <svg id="hamburger-icon" class="w-7 h-7" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                    <path id="hamburger-path" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7"></path>
+                </svg>
+            </button>
+        </nav>
+        <div id="mobile-menu" class="hidden lg:hidden bg-[#215240] py-4">
+            <a href="index.html" class="block text-center py-2 px-4 text-base text-white hover:bg-opacity-10 hover:bg-white">Home</a>
+            <a href="servis-sourcing-procurement.html" class="block text-center py-2 px-4 text-base text-white hover:bg-opacity-10 hover:bg-white">Sourcing & Procurement</a>
+            <div class="mobile-dropdown-toggle block text-center py-2 px-4 text-base text-white hover:bg-opacity-10 hover:bg-white cursor-pointer">About Us <span class="ml-1 text-xs">&#9662;</span></div>
+            <div class="mobile-dropdown-content hidden">
+                <a href="tentang-kami.html" class="block text-center py-2 px-4 text-base text-white hover:bg-opacity-10 hover:bg-white">Tentang Kami</a>
+                <a href="soalan-lazim.html" class="block text-center py-2 px-4 text-base text-white hover:bg-opacity-10 hover:bg-white">Soalan Lazim</a>
+            </div>
+            <div class="mobile-dropdown-toggle block text-center py-2 px-4 text-base text-white hover:bg-opacity-10 hover:bg-white cursor-pointer">Activity <span class="ml-1 text-xs">&#9662;</span></div>
+            <div class="mobile-dropdown-content hidden">
+                <a href="key-in.html" class="block text-center py-2 px-4 text-base text-white hover:bg-opacity-10 hover:bg-white">Key-In Tempahan</a>
+                <a href="register.html" class="block text-center py-2 px-4 text-base text-white hover:bg-opacity-10 hover:bg-white">Daftar Sekarang</a>
+            </div>
+            <div class="mobile-dropdown-toggle block text-center py-2 px-4 text-base text-white hover:bg-opacity-10 hover:bg-white cursor-pointer">Careers <span class="ml-1 text-xs">&#9662;</span></div>
+            <div class="mobile-dropdown-content hidden">
+                <a href="kelebihan.html" class="block text-center py-2 px-4 text-base text-white hover:bg-opacity-10 hover:bg-white">Kelebihan</a>
+            </div>
+            <div class="mobile-dropdown-toggle block text-center py-2 px-4 text-base text-white hover:bg-opacity-10 hover:bg-white cursor-pointer">Shop <span class="ml-1 text-xs">&#9662;</span></div>
+            <div class="mobile-dropdown-content hidden">
+                <a href="bahan-hq.html" class="block text-center py-2 px-4 text-base text-white hover:bg-opacity-10 hover:bg-white">Bahan HQ</a>
+                <a href="potensi-pendapatan.html" class="block text-center py-2 px-4 text-base text-white hover:bg-opacity-10 hover:bg-white">Potensi Pendapatan</a>
+                <a href="sokongan.html" class="block text-center py-2 px-4 text-base text-white hover:bg-opacity-10 hover:bg-white">Sokongan</a>
+            </div>
+            <a href="info-kit/MODUL-LENGKAP-EJEN-PROCUTRACK.pdf" target="_blank" download class="block text-center py-3 px-4 text-base bg-[#215240] text-white font-bold cta-button mt-2 mx-6">Muat Turun Info Kit</a>
+        </div>
+    </header>
+
+    <main>
+        <section class="py-20">
+            <div class="container mx-auto px-6 text-center max-w-3xl">
+                <h1 class="text-4xl font-bold mb-6 text-[#215240]">Servis Sourcing & Procurement</h1>
+                <p class="text-lg text-gray-700 mb-6">ProcuTrack menyediakan servis lengkap dari pencarian vendor hingga penghantaran akhir. Kami memastikan produk yang anda perlukan diperoleh dengan kos berpatutan dan kualiti terjamin.</p>
+                <ul class="text-left list-disc list-inside text-gray-700 space-y-3">
+                    <li>Pencarian dan penilaian pembekal yang dipercayai di China.</li>
+                    <li>Rundingan harga dan pengurusan pesanan menyeluruh.</li>
+                    <li>Pemeriksaan kualiti dan penyelarasan logistik ke Malaysia.</li>
+                </ul>
+            </div>
+        </section>
+    </main>
+
+    <footer class="bg-gray-900 text-white py-8">
+        <div class="container mx-auto px-6 text-center">
+            <p class="text-lg">© 2024 ProcuTrack. Hak Cipta Terpelihara.</p>
+            <p class="text-base text-gray-400 mt-2">ProcuTrack - Solusi Perolehan Pintar, Bisnes Lebih Cemerlang!</p>
+            <div class="mt-4 text-base space-x-4">
+                <a href="link-ke-terma-syarat.html" class="text-gray-400 hover:text-white transition-colors duration-200">Terma & Syarat</a>
+                <span class="text-gray-500">|</span>
+                <a href="link-ke-polisi-privasi.html" class="text-gray-400 hover:text-white transition-colors duration-200">Polisi Privasi</a>
+            </div>
+        </div>
+    </footer>
+
+    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            AOS.init({ duration: 900, once: true, offset: 50 });
+
+            const mobileMenuButton = document.getElementById('mobile-menu-button');
+            const mobileMenu = document.getElementById('mobile-menu');
+            const hamburgerPath = document.getElementById('hamburger-path');
+            const hamburgerD = "M4 6h16M4 12h16m-7 6h7";
+            const closeD = "M6 18L18 6M6 6l12 12";
+
+            function toggleMobileMenu() {
+                const isOpen = !mobileMenu.classList.contains('hidden');
+                if (isOpen) {
+                    mobileMenu.classList.add('hidden');
+                    hamburgerPath.setAttribute('d', hamburgerD);
+                } else {
+                    mobileMenu.classList.remove('hidden');
+                    hamburgerPath.setAttribute('d', closeD);
+                }
+            }
+
+            mobileMenuButton.addEventListener('click', toggleMobileMenu);
+
+            mobileMenu.querySelectorAll('a').forEach(link => {
+                link.addEventListener('click', () => {
+                    if (!mobileMenu.classList.contains('hidden')) {
+                        toggleMobileMenu();
+                    }
+                });
+            });
+
+            const mobileDropdownToggles = document.querySelectorAll('.mobile-dropdown-toggle');
+            mobileDropdownToggles.forEach(toggle => {
+                toggle.addEventListener('click', function() {
+                    const content = this.nextElementSibling;
+                    if (content && content.classList.contains('mobile-dropdown-content')) {
+                        content.classList.toggle('hidden');
+                    }
+                });
+            });
+
+            const allNavLinks = document.querySelectorAll('#header nav a.nav-main-link, .dropdown-content a, #mobile-menu a');
+
+            function highlightActiveNav() {
+                const currentPathname = window.location.pathname.split('/').pop();
+
+                allNavLinks.forEach(link => {
+                    let linkHref = link.getAttribute('href');
+                    if (!linkHref) return;
+
+                    let linkPath = linkHref.split('#')[0].split('/').pop();
+
+                    link.classList.remove('nav-active-link');
+                    if (link.classList.contains('nav-main-link')) {
+                        link.classList.add('text-white', 'hover:text-[#EBF2EE]');
+                    }
+                    if (link.classList.contains('mobile-dropdown-toggle')) {
+                        link.classList.add('text-white', 'hover:bg-opacity-10', 'hover:bg-white');
+                    }
+
+                    if (linkPath === 'index.html' || linkPath === '') {
+                        if (currentPathname === 'index.html' || currentPathname === '') {
+                            link.classList.add('nav-active-link');
+                            if (link.classList.contains('nav-main-link')) {
+                                link.classList.remove('text-white', 'hover:text-[#EBF2EE]');
+                            }
+                        }
+                    } else if (currentPathname === linkPath) {
+                        link.classList.add('nav-active-link');
+                        if (link.classList.contains('nav-main-link')) {
+                            link.classList.remove('text-white', 'hover:text-[#EBF2EE]');
+                        }
+
+                        let parentDropdown = link.closest('.dropdown');
+                        if (parentDropdown) {
+                            let parentLink = parentDropdown.querySelector('.nav-main-link');
+                            if (parentLink) {
+                                parentLink.classList.add('nav-active-link');
+                                parentLink.classList.remove('text-white', 'hover:text-[#EBF2EE]');
+                            }
+                        }
+
+                        let mobileParentToggle = link.closest('.mobile-dropdown-content');
+                        if (mobileParentToggle) {
+                            mobileParentToggle.classList.remove('hidden');
+                            let toggleButton = mobileParentToggle.previousElementSibling;
+                            if (toggleButton && toggleButton.classList.contains('mobile-dropdown-toggle')) {
+                                toggleButton.classList.add('nav-active-link');
+                                toggleButton.classList.remove('text-white', 'hover:bg-opacity-10', 'hover:bg-white');
+                            }
+                        }
+                    }
+                });
+            }
+
+            highlightActiveNav();
+            window.addEventListener('hashchange', highlightActiveNav);
+            window.addEventListener('load', highlightActiveNav);
+        });
+    </script>
+</body>
+</html>

--- a/tentang-kami.html
+++ b/tentang-kami.html
@@ -339,6 +339,7 @@
             <a href="index.html" class="text-2xl font-bold text-white">Procu<span class="text-white">Track</span></a>
             
             <div class="hidden lg:flex items-center space-x-6 mx-auto"> <a href="index.html" class="nav-main-link">Home</a>
+                <a href="servis-sourcing-procurement.html" class="nav-main-link">Sourcing & Procurement</a>
                 
                 <div class="dropdown">
                     <a href="#" class="nav-main-link">About Us <span class="ml-1 text-xs">&#9662;</span></a>
@@ -381,6 +382,7 @@
         </nav>
         <div id="mobile-menu" class="hidden lg:hidden bg-[#215240] py-4">
             <a href="index.html" class="block text-center py-2 px-4 text-base text-white hover:bg-opacity-10 hover:bg-white">Home</a>
+            <a href="servis-sourcing-procurement.html" class="block text-center py-2 px-4 text-base text-white hover:bg-opacity-10 hover:bg-white">Sourcing & Procurement</a>
             <div class="mobile-dropdown-toggle block text-center py-2 px-4 text-base text-white hover:bg-opacity-10 hover:bg-white cursor-pointer">About Us <span class="ml-1 text-xs">&#9662;</span></div>
             <div class="mobile-dropdown-content hidden">
                 <a href="tentang-kami.html" class="block text-center py-2 px-4 text-base text-white hover:bg-opacity-10 hover:bg-white">Tentang Kami</a>


### PR DESCRIPTION
## Summary
- Add dedicated `Servis Sourcing & Procurement` page describing supplier search, price negotiation, and quality/logistics support
- Link new service page in desktop and mobile navigation across site

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689011e8d544833194585f1e188b3cc1